### PR TITLE
Disabling xml errors on loadHTML

### DIFF
--- a/Crawler.php
+++ b/Crawler.php
@@ -125,6 +125,7 @@ class Crawler extends \SplObjectStorage
         $dom = new \DOMDocument('1.0', $charset);
         $dom->validateOnParse = true;
 
+	libxml_use_internal_errors(true);
         @$dom->loadHTML($content);
         $this->addDocument($dom);
 


### PR DESCRIPTION
When crawling facebook pages, some "Notice: DOMDocument::loadHTML(): Namespace prefix fb is not defined in Entity" appears.
Fixed by removing errors notices of xml.
