### PR TITLE
Make the getNode function public

### DIFF
--- a/Crawler.php
+++ b/Crawler.php
@@ -662,7 +662,7 @@ class Crawler extends \SplObjectStorage
         return sprintf("concat(%s)", implode($parts, ', '));
     }
 
-    private function getNode($position)
+    public function getNode($position)
     {
         foreach ($this as $i => $node) {
             if ($i == $position) {


### PR DESCRIPTION
It is not possible to get the first of any node in a crawler. It is only possible to generate a new crawler with the function eq(), but in my case, i needed the node. It would be nice, if this will be pushed into the master
