### PR TITLE
Fix DOMDocument's incompatibility with HTML5

### DIFF
--- a/Crawler.php
+++ b/Crawler.php
@@ -125,7 +125,7 @@ class Crawler extends \SplObjectStorage
         $dom->validateOnParse = true;
 
         $current = libxml_use_internal_errors(true);
-        @$dom->loadHTML($content);
+        @$dom->loadHTML('<?xml encoding="'.$charset.'">'.$content);
         libxml_use_internal_errors($current);
 
         $this->addDocument($dom);


### PR DESCRIPTION
DOMDocument never use constructor specified charset, instead meta-tag or XML-PI are used absolutely.
So `<meta charset="UTF-8" />` and detected charset from HTTP header was totally ignored by DOMDocument.

See: http://www.php.net/manual/ja/domdocument.loadhtml.php#95251
