### PR TITLE
Allows using multiselect through Form::setValues().

### DIFF
--- a/Form.php
+++ b/Form.php
@@ -494,13 +494,14 @@ class FormFieldRegistry
     public function set($name, $value)
     {
         $target =& $this->get($name);
-        if (is_array($value)) {
+        if (!is_array($value) || $target instanceof Field\ChoiceFormField) {
+            $target->setValue($value);
+        }
+        else {
             $fields = self::create($name, $value);
             foreach ($fields->all() as $k => $v) {
                 $this->set($k, $v);
             }
-        } else {
-            $target->setValue($value);
         }
     }
 

--- a/Tests/FormTest.php
+++ b/Tests/FormTest.php
@@ -273,6 +273,13 @@ class FormTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('bar' => 'foo'), $form->getValues(), '->setValues() sets the values of fields');
     }
 
+    public function testMultiselectSetValues()
+    {
+        $form = $this->createForm('<form><select multiple="multiple" name="multi"><option value="foo">foo</option><option value="bar">bar</option></select><input type="submit" /></form>');
+        $form->setValues(array('multi' => array("foo", "bar")));
+        $this->assertEquals(array('multi' => array('foo', 'bar')), $form->getValues(), '->setValue() sets tehe values of select');
+    }
+
     public function testGetPhpValues()
     {
         $form = $this->createForm('<form><input type="text" name="foo[bar]" value="foo" /><input type="text" name="bar" value="bar" /><input type="submit" /></form>');


### PR DESCRIPTION
Patch allows set multiple values in select using setValues() method, as it is used in Symfony\Component\BrowserKit\Client::submit().
