### PR TITLE
Fix `extract` method to avoid recalculating count() for each iteration.

### DIFF
--- a/Crawler.php
+++ b/Crawler.php
@@ -554,6 +554,7 @@ class Crawler extends \SplObjectStorage
     public function extract($attributes)
     {
         $attributes = (array) $attributes;
+        $count = count($attributes);
 
         $data = array();
         foreach ($this as $node) {
@@ -566,7 +567,7 @@ class Crawler extends \SplObjectStorage
                 }
             }
 
-            $data[] = count($attributes) > 1 ? $elements : $elements[0];
+            $data[] = $count > 1 ? $elements : $elements[0];
         }
 
         return $data;


### PR DESCRIPTION
Cache the value of `count($attributes)` to avoid recalculating it for each iteration of the loop.

Since this count will never change during the method execution, this change make the code a bit more efficient.
