### PR TITLE
Adding node name getter with tests

### DIFF
--- a/Crawler.php
+++ b/Crawler.php
@@ -505,6 +505,24 @@ class Crawler extends \SplObjectStorage
     }
 
     /**
+     * Returns the node name of the first node of the list.
+     *
+     * @return string The node name
+     *
+     * @throws \InvalidArgumentException When current node is empty
+     *
+     * @api
+     */
+    public function name()
+    {
+        if (!count($this)) {
+            throw new \InvalidArgumentException('The current node list is empty.');
+        }
+
+        return $this->getNode(0)->nodeName;
+    }
+
+    /**
      * Returns the node value of the first node of the list.
      *
      * @return string The node value

--- a/Tests/CrawlerTest.php
+++ b/Tests/CrawlerTest.php
@@ -344,6 +344,18 @@ EOF
         $this->assertNull($div->attr('missing-attr'), '->attr() reads missing attributes correctly');
     }
 
+    public function testName()
+    {
+        $this->assertEquals('li', $this->createTestCrawler()->filterXPath('//li')->name(), '->name() returns the node name of the first element of the node list');
+
+        try {
+            $this->createTestCrawler()->filterXPath('//ol')->name();
+            $this->fail('->name() throws an \InvalidArgumentException if the node list is empty');
+        } catch (\InvalidArgumentException $e) {
+            $this->assertTrue(true, '->name() throws an \InvalidArgumentException if the node list is empty');
+        }
+    }
+
     public function testText()
     {
         $this->assertEquals('One', $this->createTestCrawler()->filterXPath('//li')->text(), '->text() returns the node value of the first element of the node list');


### PR DESCRIPTION
Based on the use case came up in a SO question (http://stackoverflow.com/questions/22564465/getting-the-tag-name-of-a-element-crawled-with-domcrawler-in-php) I propose a new helper function to get the name of the active node
