### PR TITLE
change each and reduce to accept callable parameter + tests

### DIFF
--- a/Crawler.php
+++ b/Crawler.php
@@ -340,7 +340,7 @@ class Crawler extends \SplObjectStorage
      *
      * @api
      */
-    public function each(\Closure $closure)
+    public function each(callable $closure)
     {
         $data = array();
         foreach ($this as $i => $node) {
@@ -374,7 +374,7 @@ class Crawler extends \SplObjectStorage
      *
      * @api
      */
-    public function reduce(\Closure $closure)
+    public function reduce(callable $closure)
     {
         $nodes = array();
         foreach ($this as $i => $node) {

--- a/Tests/CrawlerTest.php
+++ b/Tests/CrawlerTest.php
@@ -313,6 +313,12 @@ EOF
         $this->assertEquals(array('0-One', '1-Two', '2-Three'), $data, '->each() executes an anonymous function on each node of the list');
     }
 
+    public function testEachWithCallable()
+    {
+        $data = $this->createTestCrawler()->filterXPath('//ul[1]/li')->each(array($this, 'hyphenateNumber'));
+        $this->assertEquals(array('0-One', '1-Two', '2-Three'), $data, '->each() executes an anonymous function on each node of the list');
+    }
+
     public function testSlice()
     {
         $crawler = $this->createTestCrawler()->filterXPath('//ul[1]/li');
@@ -329,6 +335,16 @@ EOF
         $nodes = $crawler->reduce(function ($node, $i) {
             return $i !== 1;
         });
+        $this->assertNotSame($nodes, $crawler, '->reduce() returns a new instance of a crawler');
+        $this->assertInstanceOf('Symfony\\Component\\DomCrawler\\Crawler', $nodes, '->reduce() returns a new instance of a crawler');
+
+        $this->assertCount(2, $nodes, '->reduce() filters the nodes in the list');
+    }
+
+    public function testReduceWithCallable()
+    {
+        $crawler = $this->createTestCrawler()->filterXPath('//ul[1]/li');
+        $nodes = $crawler->reduce(array($this, 'isNotOne'));
         $this->assertNotSame($nodes, $crawler, '->reduce() returns a new instance of a crawler');
         $this->assertInstanceOf('Symfony\\Component\\DomCrawler\\Crawler', $nodes, '->reduce() returns a new instance of a crawler');
 
@@ -1075,5 +1091,15 @@ HTML;
         $domxpath = new \DOMXPath($dom);
 
         return $domxpath->query('//div');
+    }
+
+    public function hyphenateNumber($node, $i)
+    {
+        return $i.'-'.$node->text();
+    }
+
+    public function isNotOne($node, $i)
+    {
+        return $i !== 1;
     }
 }


### PR DESCRIPTION
Hey DomCrawler Team,

First off, I love DomCrawler and thanks for the great product! I recently found myself working on a project where I wanted to pass a method to each() and discovered I could not. Previously the parameter had to be an instance of \Closure so I updated it to accept a parameter of type callable instead. This allowed me to pass methods using the form array($object, 'methodName') as well as closures.