### PR TITLE
Update Crawler.php

### DIFF
--- a/Crawler.php
+++ b/Crawler.php
@@ -1110,7 +1110,7 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * @throws \InvalidArgumentException
      */
-    private function discoverNamespace(\DOMXPath $domxpath, string $prefix): string
+    private function discoverNamespace(\DOMXPath $domxpath, string $prefix):? string
     {
         if (isset($this->namespaces[$prefix])) {
             return $this->namespaces[$prefix];
@@ -1122,6 +1122,7 @@ class Crawler implements \Countable, \IteratorAggregate
         if ($node = $namespaces->item(0)) {
             return $node->nodeValue;
         }
+        return null;
     }
 
     private function findNamespacePrefixes(string $xpath): array


### PR DESCRIPTION
fix bug Return value of Symfony\Component\DomCrawler\Crawler::discoverNamespace() must be of the type string or null, none returned