### PR TITLE
Update Crawler.php with syntax fix

### DIFF
--- a/Crawler.php
+++ b/Crawler.php
@@ -1107,7 +1107,7 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * @throws \InvalidArgumentException
      */
-    private function discoverNamespace(\DOMXPath $domxpath, string $prefix): ?string
+    private function discoverNamespace(\DOMXPath $domxpath, string $prefix): string
     {
         if (isset($this->namespaces[$prefix])) {
             return $this->namespaces[$prefix];


### PR DESCRIPTION
Remove syntax error preventing component from being used. Accidental '?' in return hint.
Thanks!