### PR TITLE
Added return of element name in `extract()` method

### DIFF
--- a/Crawler.php
+++ b/Crawler.php
@@ -658,6 +658,8 @@ class Crawler implements \Countable, \IteratorAggregate
             foreach ($attributes as $attribute) {
                 if ('_text' === $attribute) {
                     $elements[] = $node->nodeValue;
+                } elseif ('_key' === $attribute) {
+                    $elements[] = $node->nodeName;
                 } else {
                     $elements[] = $node->getAttribute($attribute);
                 }


### PR DESCRIPTION
Situation: you need to get an array of keys and values.
The current package code does not allow this to be done easily.
The changes made to the code will allow you to return the required data set.
```php
use Symfony\Component\DomCrawler\Crawler;

$crawler = new Crawler($content);

$crawler
    ->filter('ItemsList > Item')
    ->each(function (Crawler $element) {
        $data = $element
            ->children()
            ->extract(['_key', '_text']);

        var_dump($data);
    });

// Result:
array:2 [
  0 => array:2 [
    0 => "id",
    1 => "1"
  ],
  1 => array:2 [
    0 => "title",
    1 => "Foo Bar"
  ]
]
```