### PR TITLE
Test against all matches

### DIFF
--- a/Test/Constraint/CrawlerSelectorAttributeValueSame.php
+++ b/Test/Constraint/CrawlerSelectorAttributeValueSame.php
@@ -47,7 +47,13 @@ final class CrawlerSelectorAttributeValueSame extends Constraint
             return false;
         }
 
-        return $this->expectedText === trim($crawler->attr($this->attribute));
+        foreach($crawler as $node){
+            $attrValue = $node->hasAttribute($this->attribute) ? trim($node->getAttribute($this->attribute)) : null;
+            if ($this->expectedText === $attrValue){
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/Test/Constraint/CrawlerSelectorTextContains.php
+++ b/Test/Constraint/CrawlerSelectorTextContains.php
@@ -44,8 +44,13 @@ final class CrawlerSelectorTextContains extends Constraint
         if (!\count($crawler)) {
             return false;
         }
-
-        return false !== mb_strpos($crawler->text(null, false), $this->expectedText);
+        
+        foreach($crawler as $node){
+            if (false !== mb_strpos($node->nodeValue, $this->expectedText)){
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/Test/Constraint/CrawlerSelectorTextSame.php
+++ b/Test/Constraint/CrawlerSelectorTextSame.php
@@ -44,8 +44,13 @@ final class CrawlerSelectorTextSame extends Constraint
         if (!\count($crawler)) {
             return false;
         }
-
-        return $this->expectedText === trim($crawler->text(null, false));
+        
+        foreach($crawler as $node){
+            if ($this->expectedText === trim($node->nodeValue)){
+                return true;
+            }
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
The Symfony [documentation](https://symfony.com/doc/current/testing.html) explains that...

>  To assert that the phrase "Hello World" is present in the page's main title, you can use this assertion:

`$this->assertSelectorTextContains('html h1.title', 'Hello World');`

> Using native PHPUnit methods, the same assertion would look like this:

`
$this->assertGreaterThan(
    0,
    $crawler->filter('html h1.title:contains("Hello World")')->count()
);
`

**..this is ONLY true if the selector has only one match.**

This pull requests changes the constraint behaviour to compare all matches against the provided criteria. If this is not the desired behaviour, please fix the documentation.