### PR TITLE
impossible to test a value out of the options in ChoiceFormField

### DIFF
--- a/Field/ChoiceFormField.php
+++ b/Field/ChoiceFormField.php
@@ -118,8 +118,6 @@ class ChoiceFormField extends FormField
                         throw new \InvalidArgumentException(sprintf('Input "%s" cannot take "%s" as a value (possible values: "%s").', $this->name, $v, implode('", "', $this->availableOptionValues())));
                     }
                 }
-            } elseif (!$this->containsOption($value, $this->options)) {
-                throw new \InvalidArgumentException(sprintf('Input "%s" cannot take "%s" as a value (possible values: "%s").', $this->name, $value, implode('", "', $this->availableOptionValues())));
             }
 
             if ($this->multiple) {


### PR DESCRIPTION
I couldn't test a value outside of the ChoiceForm field option nodes.
For example, even if my combobox does not offer the empty field, I want to test my NotBlank validator.

```php
<?php
$form = $crawler->selectButton('ea[newForm][btn]')->form();
$client->submit($form, [
    'Item[vat]' => ''
]);
```

in Symfony\Component\BrowserKit\AbstractBrowser::submit ($client->submit())
````php
public function submit(Form $form, array $values = [], array $serverParameters = []): Crawler
{
        $form->setValues($values);

        return $this->request($form->getMethod(), $form->getUri(), $form->getPhpValues(), $form->getPhpFiles(), $serverParameters);
}
````


`InvalidArgumentException: Input "Item[vat]" cannot take "" as a value (possible values: "0", "700", "1900").`

maybe there is another solution ?


Thanks