### PR TITLE
Fix issue #48682

### DIFF
--- a/Tests/AbstractCrawlerTest.php
+++ b/Tests/AbstractCrawlerTest.php
@@ -362,8 +362,8 @@ abstract class AbstractCrawlerTest extends TestCase
     {
         self::assertCount(1, $crawler = $this->createTestCrawler()->filterXPath('//*[@id="complex-element"]'));
 
-        self::assertSame('Parent text Child text', $crawler->text());
-        self::assertSame('Parent text', $crawler->innerText());
+        self::assertSame('Parent text Child text More parent text', $crawler->text());
+        self::assertSame('Parent text More parent text', $crawler->innerText());
     }
 
     public function testHtml()
@@ -1303,6 +1303,7 @@ HTML;
                     <div id="complex-element">
                         Parent text
                         <span>Child text</span>
+                        More parent text
                     </div>
                 </body>
             </html>


### PR DESCRIPTION
Fixes the issue described in
https://github.com/symfony/symfony/issues/48682

Further align the signature of the `innerText()` method with the `text()` method by adding optional default value and normalizeWhitespace arguments and extract normalizing whitespace to a shared method.

I've also copied over the behavior of throwing an `InvalidArgumentException` when the current node list is empty from the `text()` method. Sadly that's duplicate code now, but I've also seen that there are a lot of different places where that kind of exception is thrown.